### PR TITLE
create coupon

### DIFF
--- a/src/main/java/me/zilzu/mycoupon/api/controller/CouponController.java
+++ b/src/main/java/me/zilzu/mycoupon/api/controller/CouponController.java
@@ -2,12 +2,9 @@ package me.zilzu.mycoupon.api.controller;
 
 import me.zilzu.mycoupon.application.service.Coupon;
 import me.zilzu.mycoupon.application.service.CouponService;
-import org.springframework.http.HttpRequest;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,6 +38,14 @@ public class CouponController {
                 .map(CouponRetrieveResultResponse::new)
                 .collect(Collectors.toList());
         return new CouponRetrieveListResponse("list", requestURI, false, couponListResults);
+    }
+
+    @PostMapping("/api/v1/coupons")
+    public CouponCreatedResponse createCoupons(@RequestBody CouponRequest couponRequest) {
+
+        Coupon coupon = couponService.create(couponRequest);
+
+        return new CouponCreatedResponse(coupon);
     }
 
 }

--- a/src/main/java/me/zilzu/mycoupon/api/controller/CouponCreatedResponse.java
+++ b/src/main/java/me/zilzu/mycoupon/api/controller/CouponCreatedResponse.java
@@ -1,0 +1,34 @@
+package me.zilzu.mycoupon.api.controller;
+
+import me.zilzu.mycoupon.application.service.Coupon;
+
+public class CouponCreatedResponse {
+
+    public String id;
+    public String object;
+    public Integer amountOff;
+    public long created;
+    public String currency;
+    public String duration;
+    public Integer durationInMonths;
+    public Boolean livemode;
+    public Integer maxRedemptions;
+    public String name;
+    public Float percentOff;
+    public Boolean valid;
+
+    public CouponCreatedResponse(Coupon coupon) {
+        this.id = coupon.id;
+        this.object = coupon.object;
+        this.amountOff = coupon.amountOff;
+        this.created = coupon.created;
+        this.currency = coupon.currency;
+        this.duration = coupon.duration;
+        this.durationInMonths = coupon.durationInMonths;
+        this.livemode = coupon.livemode;
+        this.maxRedemptions = coupon.maxRedemptions;
+        this.name = coupon.name;
+        this.percentOff = coupon.percentOff;
+        this.valid = coupon.valid;
+    }
+}

--- a/src/main/java/me/zilzu/mycoupon/api/controller/CouponRequest.java
+++ b/src/main/java/me/zilzu/mycoupon/api/controller/CouponRequest.java
@@ -1,0 +1,20 @@
+package me.zilzu.mycoupon.api.controller;
+
+public class CouponRequest {
+    private final String duration;
+    private final Integer durationInMonths;
+
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public Integer getDurationInMonths() {
+        return durationInMonths;
+    }
+
+    public CouponRequest(String duration, Integer durationInMonths) {
+        this.duration = duration;
+        this.durationInMonths = durationInMonths;
+    }
+}

--- a/src/main/java/me/zilzu/mycoupon/application/service/CouponService.java
+++ b/src/main/java/me/zilzu/mycoupon/application/service/CouponService.java
@@ -1,5 +1,6 @@
 package me.zilzu.mycoupon.application.service;
 
+import me.zilzu.mycoupon.api.controller.CouponRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -25,5 +26,12 @@ public class CouponService {
         }
 
         return coupons;
+    }
+
+    public Coupon create(CouponRequest couponRequest) {
+
+        return new Coupon("Z4OV52SU", "coupon", null, System.currentTimeMillis() / 1000, "usd",
+                couponRequest.getDuration(), couponRequest.getDurationInMonths(), false,
+                null, "25.5% off", 25.5F, true);
     }
 }


### PR DESCRIPTION
# RequestBody
- 기억하자 MappingJackson2HttpMessageConverter
- header에 Content-Type : application/json 이라 들어오면 이놈이 처리한다.

- 한 가지 삽질을 좀 했는데
- body 메시지에 

```
{
  "couponRequest": {
    "duration" : "3",
    "durationInMonths" : 3
  }
}
```
이렇게 보내고 있었던 것..  이러니 couponRequest 객체에 바인딩이 제대로 되지 않았다. 
RequestBody는 body로 들어온 json의 element를 객체의 element로 바인딩 시켜준다!
```
  {
    "duration" : "3",
    "durationInMonths" : 3
  }
```
이렇게 하니 정상적으로 바인딩 되었다. !
